### PR TITLE
Add support for char literals in textmate grammar

### DIFF
--- a/language-configuration.json
+++ b/language-configuration.json
@@ -13,11 +13,14 @@
     ],
     // symbols that are auto closed when typing
     "autoClosingPairs": [
-        ["{", "}"],
-        ["[", "]"],
-        ["(", ")"],
-        ["\"", "\""],
-        ["'", "'"]
+         // Should not autoclose in char literals,
+         // but the only option is string literals, so that'll have to do
+        { "open": "{", "close": "}", "notIn": ["string"] },
+        { "open": "{-", "close": "-}", "notIn": ["string"] },
+        { "open": "[", "close": "]", "notIn": ["string"] },
+        { "open": "(", "close": ")", "notIn": ["string"] },
+        { "open": "\"", "close": "\"", "notIn": ["string"] },
+        { "open": "`", "close": "`", "notIn": ["string", "comment"]},
     ],
     // symbols that can be used to surround a selection
     "surroundingPairs": [
@@ -25,6 +28,9 @@
         ["[", "]"],
         ["(", ")"],
         ["\"", "\""],
-        ["'", "'"]
-    ]
+        ["`", "`"]
+    ],
+    "folding": {
+      "offSide": true
+    }
 }

--- a/syntaxes/unison.tmLanguage.json
+++ b/syntaxes/unison.tmLanguage.json
@@ -10,6 +10,8 @@
   },{
     "include": "#text"
   },{
+    "include": "#char"
+  },{
     "include": "#match_with"
   },{
     "include": "#control"
@@ -69,6 +71,8 @@
         "include": "#eof_comment"
       },{
         "include": "#line_comment"
+      },{
+        "include": "#block_comment"
       }]
     },
     "eof_comment": {
@@ -155,13 +159,37 @@
     },
     "text": {
       "name": "string.quoted.double.unison",
-      "match": "(\")(.*?)(\")",
+      "begin": "\"",
+      "end": "\"",
+      "beginCaptures": {
+        "0": {
+          "name": "punctuation.definition.string.begin.unison"
+        }
+      },
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.definition.string.end.unison"
+        }
+      },
+      "patterns": [
+        {
+          "name": "constant.character.escape.unison",
+          "match": "\\\\."
+        }
+      ]
+    },
+    "char": {
+      "name": "string.quoted.single.unison",
+      "match": "([?])(([\\\\].)|([^\\\\]))",
       "captures": {
         "1": {
           "name": "punctuation.definition.string.begin.unison"
         },
         "3": {
-          "name": "punctuation.definition.string.end.unison"
+          "name": "constant.character.escape.unison"
+        },
+        "4": {
+          "name": "string.quoted.single.unison"
         }
       }
     },


### PR DESCRIPTION
- Fixes #3
- Also improves highlighting for string literals with escape sequences
  (Not complete, just basic single character escape, no support for hex)
- Actually include the block comment syntax in the grammar
- Add more autoclosing pairs and disable them in char literals