### PR TITLE
Add log output

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "unison",
-    "version": "0.0.1",
+    "version": "0.0.6",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "unison",
-            "version": "0.0.1",
+            "version": "0.0.6",
             "license": "SEE LICENSE IN LICENSE",
             "dependencies": {
                 "vscode-languageclient": "^8.0.1"
@@ -15,7 +15,7 @@
                 "@types/node": "^18.0.3",
                 "@types/vscode": "^1.69.0",
                 "esbuild": "^0.14.49",
-                "typescript": "^4.7.2",
+                "typescript": "^4.8.4",
                 "vsce": "^2.9.2"
             },
             "engines": {
@@ -1474,9 +1474,9 @@
             }
         },
         "node_modules/typescript": {
-            "version": "4.7.4",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.4.tgz",
-            "integrity": "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==",
+            "version": "4.8.4",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.4.tgz",
+            "integrity": "sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==",
             "dev": true,
             "bin": {
                 "tsc": "bin/tsc",
@@ -2618,9 +2618,9 @@
             }
         },
         "typescript": {
-            "version": "4.7.4",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.4.tgz",
-            "integrity": "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==",
+            "version": "4.8.4",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.4.tgz",
+            "integrity": "sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==",
             "dev": true
         },
         "uc.micro": {

--- a/package.json
+++ b/package.json
@@ -82,7 +82,6 @@
     "scripts": {
         "compile": "tsc -b",
         "watch": "tsc -b -w",
-
         "vscode:prepublish": "npm run esbuild-base -- --minify",
         "vscode:package": "npm run vscode:prepublish && vsce package",
         "esbuild-base": "esbuild ./src/extension.ts --bundle --outfile=out/main.js --external:vscode --format=cjs --platform=node",
@@ -96,7 +95,7 @@
         "@types/node": "^18.0.3",
         "@types/vscode": "^1.69.0",
         "esbuild": "^0.14.49",
-        "typescript": "^4.7.2",
+        "typescript": "^4.8.4",
         "vsce": "^2.9.2"
     },
     "license": "SEE LICENSE IN LICENSE"


### PR DESCRIPTION
Hi! trying to debug the use of the extension in windows i've added some log output. I think it can be useful to help users investogate the cause of errors and report them.
As the extension is trying to connect indefinitely, tries will be appended also continuosly, but i think it is good give some signal the extension is doing it

npm has upgraded typescript version automatically, i can remove that commit if you think it should not br included in this pr.

Output example of a failing attempt in my windows 10:

```
Activating unison language server at d:\dev\ws\unison\learn
Trying to connect to ucm lsp server at 127.0.0.1:5757
Language server failed to connect, cause: Error: connect ECONNREFUSED 127.0.0.1:5757
Trying to connect to ucm lsp server at 127.0.0.1:5757
Language server failed to connect, cause: Error: connect ECONNREFUSED 127.0.0.1:5757
Trying to connect to ucm lsp server at 127.0.0.1:5757
Language server failed to connect, cause: Error: connect ECONNREFUSED 127.0.0.1:5757
Trying to connect to ucm lsp server at 127.0.0.1:5757
Language server failed to connect, cause: Error: connect ECONNREFUSED 127.0.0.1:5757
Trying to connect to ucm lsp server at 127.0.0.1:5757
Language server failed to connect, cause: Error: connect ECONNREFUSED 127.0.0.1:5757
Trying to connect to ucm lsp server at 127.0.0.1:5757
....
```