### PR TITLE
Fixing typo in 'extensions' path and adding "npm i" step

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,8 @@ See the [CHANGELOG](./CHANGELOG.md) for updates.
 ## Development
 
 * Clone the project
-* Symlink the project into your `~/.vscode/extensions` folder, e.g. `ln -s ~/Projects/vscode-unison ~/.vscode/extension/unison-dev`
+* Symlink the project into your `~/.vscode/extensions` folder, e.g. `ln -s ~/Projects/vscode-unison ~/.vscode/extensions/unison-dev`
+* `npm i`
 * `npm run watch`
 * Restart Visual Studio Code
 


### PR DESCRIPTION
This one is extremely simple.
Just for sake of correctness :)

- [x]  It's plural extensions, not extension
- [x]  `npm i` command should be run at least for the first time when building the extension