### PR TITLE
Set up CI to publish releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,7 @@ on:
       - created
 jobs:
   build:
+    name: Build
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -23,7 +24,8 @@ jobs:
         with:
           name: unison-${{ github.sha }}.vsix
           path: unison.vsix
-  release-github:
+  publish-gh:
+    name: Publish to GitHub
     needs: build
     runs-on: ubuntu-latest
     steps:
@@ -39,7 +41,8 @@ jobs:
         with:
           asset_name: unison-${{ github.event.release.tag_name }}.vsix
           file: unison.vsix
-  release-vscode:
+  publish-vsc:
+    name: Publish to Visual Studio Code Marketplace
     needs: build
     runs-on: ubuntu-latest
     steps:
@@ -50,7 +53,8 @@ jobs:
           path: unison.vsix
       - if: github.event_name == 'release'
         run: npx vsce publish --packagePath unison.vsix --pat "${{ secrets.AZURE_PAT }}"
-  release-openvsx:
+  publish-ovsx:
+    name: Publish to Open VSX
     needs: build
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: Workflow
+name: CI
 on:
   pull_request:
     branches:
@@ -23,14 +23,52 @@ jobs:
         with:
           name: unison-${{ github.sha }}.vsix
           path: unison.vsix
+  release-github:
+    if: github.event_name == 'release'
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+      - uses: actions/download-artifact@v4
+        with:
+          name: unison-${{ github.sha }}.vsix
+          path: unison.vsix
       - env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        if: github.event_name == 'release'
         uses: svenstaro/upload-release-action@v2
         with:
           asset_name: unison-${{ github.event.release.tag_name }}.vsix
           file: unison.vsix
+  release-vscode:
+    if: github.event_name == 'release'
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+      - uses: actions/download-artifact@v4
+        with:
+          name: unison-${{ github.sha }}.vsix
+          path: unison.vsix
       - if: github.event_name == 'release'
         run: npx vsce publish --packagePath unison.vsix --pat "${{ secrets.AZURE_PAT }}"
+  release-openvsx:
+    if: github.event_name == 'release'
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+      - uses: actions/download-artifact@v4
+        with:
+          name: unison-${{ github.sha }}.vsix
+          path: unison.vsix
       - if: github.event_name == 'release'
         run: npx ovsx publish --packagePath unison.vsix --pat "${{ secrets.OVSX_PAT }}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,7 @@ jobs:
           name: unison-${{ github.sha }}.vsix
           path: unison.vsix
   publish-gh:
+    if: github.event_name == 'release'
     name: Publish to GitHub
     needs: build
     runs-on: ubuntu-latest
@@ -36,12 +37,12 @@ jobs:
           path: unison.vsix
       - env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        if: github.event_name == 'release'
         uses: svenstaro/upload-release-action@v2
         with:
           asset_name: unison-${{ github.event.release.tag_name }}.vsix
           file: unison.vsix
   publish-vsc:
+    if: github.event_name == 'release'
     name: Publish to Visual Studio Code Marketplace
     needs: build
     runs-on: ubuntu-latest
@@ -51,9 +52,9 @@ jobs:
         with:
           name: unison-${{ github.sha }}.vsix
           path: unison.vsix
-      - if: github.event_name == 'release'
-        run: npx vsce publish --packagePath unison.vsix --pat "${{ secrets.AZURE_PAT }}"
+      - run: npx vsce publish --packagePath unison.vsix --pat "${{ secrets.AZURE_PAT }}"
   publish-ovsx:
+    if: github.event_name == 'release'
     name: Publish to Open VSX
     needs: build
     runs-on: ubuntu-latest
@@ -63,5 +64,4 @@ jobs:
         with:
           name: unison-${{ github.sha }}.vsix
           path: unison.vsix
-      - if: github.event_name == 'release'
-        run: npx ovsx publish --packagePath unison.vsix --pat "${{ secrets.OVSX_PAT }}"
+      - run: npx ovsx publish --packagePath unison.vsix --pat "${{ secrets.OVSX_PAT }}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,36 @@
+name: Workflow
+on:
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+  release:
+    types:
+      - created
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+      - run: npm install
+      - run: npx vsce package --out unison.vsix
+      - uses: actions/upload-artifact@v4
+        with:
+          name: unison-${{ github.sha }}.vsix
+          path: unison.vsix
+      - env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        if: github.event_name == 'release'
+        uses: svenstaro/upload-release-action@v2
+        with:
+          asset_name: unison-${{ github.event.release.tag_name }}.vsix
+          file: unison.vsix
+      - if: github.event_name == 'release'
+        run: npx vsce publish --packagePath unison.vsix --pat "${{ secrets.AZURE_PAT }}"
+      - if: github.event_name == 'release'
+        run: npx ovsx publish --packagePath unison.vsix --pat "${{ secrets.OVSX_PAT }}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,33 +24,26 @@ jobs:
           name: unison-${{ github.sha }}.vsix
           path: unison.vsix
   release-github:
-    if: github.event_name == 'release'
     needs: build
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 22
       - uses: actions/download-artifact@v4
         with:
           name: unison-${{ github.sha }}.vsix
           path: unison.vsix
       - env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        if: github.event_name == 'release'
         uses: svenstaro/upload-release-action@v2
         with:
           asset_name: unison-${{ github.event.release.tag_name }}.vsix
           file: unison.vsix
   release-vscode:
-    if: github.event_name == 'release'
     needs: build
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 22
       - uses: actions/download-artifact@v4
         with:
           name: unison-${{ github.sha }}.vsix
@@ -58,14 +51,10 @@ jobs:
       - if: github.event_name == 'release'
         run: npx vsce publish --packagePath unison.vsix --pat "${{ secrets.AZURE_PAT }}"
   release-openvsx:
-    if: github.event_name == 'release'
     needs: build
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 22
       - uses: actions/download-artifact@v4
         with:
           name: unison-${{ github.sha }}.vsix


### PR DESCRIPTION
Publishes releases to GitHub, VSCode marketplace, and Open VSX. Requires setting up the `AZURE_PAT` and `OVSX_PAT` repository secrets. Fixes #17. 