### PR TITLE
Highlight Unison code in Markdown code blocks

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,17 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+      {
+        "args": [
+          "--extensionDevelopmentPath=${workspaceFolder}"
+        ],
+        "name": "Test Extension",
+        "outFiles": [
+          "${workspaceFolder}/out/**/*.js"
+        ],
+        "preLaunchTask": "npm: esbuild",
+        "request": "launch",
+        "type": "extensionHost"
+      }
+    ]
+}

--- a/package.json
+++ b/package.json
@@ -45,6 +45,14 @@
                 "language": "unison",
                 "scopeName": "source.u",
                 "path": "./syntaxes/unison.tmLanguage.json"
+            },
+            {
+                "path": "./syntaxes/unison-markdown-injection.tmLanguage.json",
+                "scopeName": "markdown.unison.codeblock",
+                "injectTo": ["text.html.markdown"],
+                "embeddedLanguages": {
+                    "meta.embedded.unison": "unison"
+                }
             }
         ],
         "configuration": {

--- a/syntaxes/unison-markdown-injection.tmLanguage.json
+++ b/syntaxes/unison-markdown-injection.tmLanguage.json
@@ -1,0 +1,44 @@
+{
+    "scopeName": "markdown.unison.codeblock",
+    "injectionSelector": "L:text.html.markdown",
+    "patterns": [
+        {
+            "include": "#unison-code-block"
+        }
+    ],
+    "repository": {
+        "unison-code-block": {
+            "begin": "(^|\\G)(\\s*)(\\`{3,}|~{3,})\\s*(?i:(unison)(\\s+[^`~]*)?$)",
+            "name": "markup.fenced.block.markdown",
+            "end": "(^|\\G)(\\2|\\s{0,3})(\\3)\\s*$",
+            "beginCaptures": {
+                "3": {
+                    "name": "punctuation.definition.markdown"
+                },
+                "4": {
+                    "name": "fenced.block.language.markdown"
+                },
+                "5": {
+                    "name": "fenced.block.language.attributes.markdown"
+                }
+            },
+            "endCaptures": {
+                "3": {
+                    "name": "punctuation.definition.markdown"
+                }
+            },
+            "patterns": [
+                {
+                    "begin": "(^|\\G)(\\s*)(.*)",
+                    "while": "(^|\\G)(?!\\s*([`~]{3,})\\s*$)",
+                    "contentName": "meta.embedded.block.unison",
+                    "patterns": [
+                        {
+                            "include": "source.u"
+                        }
+                    ]
+                }
+            ]
+        }
+    }
+}


### PR DESCRIPTION
This will highlight Unison code in appropriately-tagged code blocks in any Markdown files (including transcripts).

Fixes #20 — I happened to have an example of this for another language at hand, originally cobbled together from [the official extension development docs](https://code.visualstudio.com/api/language-extensions/syntax-highlight-guide#embedded-languages) and [this example](https://github.com/mjbvz/vscode-fenced-code-block-grammar-injection-example/tree/master).

<img width="622" alt="image" src="https://github.com/user-attachments/assets/42c3cb24-adc6-47a5-83fb-1c7e97aa2aae" />


You could imagine doing a few other things to make this nicer, like highlighting `:hide` and friends as their own tokens or highlighting the `project/branch>` prompt differently in `ucm` blocks, but just getting `unison` blocks working seems like an ok starting point.

Note: I also included a launch config file for running the extension in a debug Code instance, because I can never remember the incantation to do that manually and like being able to just hit <kbd>F5</kbd>. I'm happy to drop that if you'd rather not have it included in the repo, though.